### PR TITLE
Fix indentation issue for authentication translations

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,14 @@
 de:
   language_name: Deutsch
+  authentication:
+    failure:
+      unauthenticated: 'Sie müssen sich authentifizieren, um diese Aktion durchzuführen.'
+      already_signed_up: 'Sie sind bereits registriert.'
+      invalid: 'Ungültige E-Mail oder ungültiges Passwort.'
+      already_signed_in: 'Sie sind bereits eingeschrieben.'
+      not_found_in_database: 'Ungültige E-Mail oder ungültiges Passwort.'
+    sessions:
+      broken_sign_out: 'Sie konnten sich nicht abmelden.'
   posts:
     new:
       new_post: Neuer Beitrag
@@ -23,12 +32,3 @@ de:
       are_you_sure: Sind Sie sicher?
       destroy: Löschen
       edit: Bearbeiten
-    authentication:
-      failure:
-        unauthenticated: 'Sie müssen sich authentifizieren, um diese Aktion durchzuführen.'
-        already_signed_up: 'Sie sind bereits registriert.'
-        invalid: 'Ungültige E-Mail oder ungültiges Passwort.'
-        already_signed_in: 'Sie sind bereits eingeschrieben.'
-        not_found_in_database: 'Ungültige E-Mail oder ungültiges Passwort.'
-      sessions:
-        broken_sign_out: 'Sie konnten sich nicht abmelden.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,15 @@
 
 en:
   language_name: English
+  authentication:
+    failure:
+      unauthenticated: 'You need to authenticate to perform this action.'
+      already_signed_up: 'You are already signed up.'
+      invalid: 'Invalid email or password.'
+      already_signed_in: 'You are already signed in.'
+      not_found_in_database: 'Invalid email or password.'
+    sessions:
+      broken_sign_out: 'Could not sign out.'
   posts:
     new:
       new_post: New Post
@@ -54,12 +63,3 @@ en:
       are_you_sure: Are you sure?
       destroy: Destroy
       edit: Edit
-    authentication:
-      failure:
-        unauthenticated: 'You need to authenticate to perform this action.'
-        already_signed_up: 'You are already signed up.'
-        invalid: 'Invalid email or password.'
-        already_signed_in: 'You are already signed in.'
-        not_found_in_database: 'Invalid email or password.'
-      sessions:
-        broken_sign_out: 'Could not sign out.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,14 @@
 fr:
   language_name: Français
+  authentication:
+    failure:
+      unauthenticated: 'Vous devez vous connecter pour effectuer cette action.'
+      already_signed_up: 'Vous êtes déjà inscrit.'
+      invalid: 'Adresse électronique ou mot de passe non valide.'
+      already_signed_in: 'Vous êtes déjà connecté.'
+      not_found_in_database: 'Adresse électronique ou mot de passe non valide.'
+    sessions:
+      broken_sign_out: 'Impossible de vous déconnecter.'
   posts:
     new:
       new_post: Nouveau Post
@@ -23,12 +32,3 @@ fr:
       are_you_sure: Êtes-vous sûr ?
       destroy: Détruire
       edit: Modifier
-    authentication:
-      failure:
-        unauthenticated: 'Vous devez vous connecter pour effectuer cette action.'
-        already_signed_up: 'Vous êtes déjà inscrit.'
-        invalid: 'Adresse électronique ou mot de passe non valide.'
-        already_signed_in: 'Vous êtes déjà connecté.'
-        not_found_in_database: 'Adresse électronique ou mot de passe non valide.'
-      sessions:
-        broken_sign_out: 'Impossible de vous déconnecter.'

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,5 +1,14 @@
 uk:
   language_name: Українська
+  authentication:
+    failure:
+      unauthenticated: 'Щоб виконати цю дію, вам необхідно пройти авторизацію.'
+      already_signed_up: 'Ви вже зареєстровані.'
+      invalid: 'Невірна адреса електронної пошти або пароль.'
+      already_signed_in: 'Ви вже зайшли в свій обліковий запис.'
+      not_found_in_database: 'Невірна адреса електронної пошти або пароль.'
+    sessions:
+      broken_sign_out: 'Не вдалося вийти з вашого облікового запису.'
   posts:
     new:
       new_post: Новий Допис
@@ -23,12 +32,3 @@ uk:
       are_you_sure: Ви впевнені?
       destroy: Знищити
       edit: Редагувати
-    authentication:
-      failure:
-        unauthenticated: 'Щоб виконати цю дію, вам необхідно пройти авторизацію.'
-        already_signed_up: 'Ви вже зареєстровані.'
-        invalid: 'Невірна адреса електронної пошти або пароль.'
-        already_signed_in: 'Ви вже зайшли в свій обліковий запис.'
-        not_found_in_database: 'Невірна адреса електронної пошти або пароль.'
-      sessions:
-        broken_sign_out: 'Не вдалося вийти з вашого облікового запису.'


### PR DESCRIPTION
Before fix:
```
$ rails c
[1] pry(main)> I18n.t('authentication.failure.already_signed_up')
=> "translation missing: en.authentication.failure.already_signed_up"
```

After fix:
```
$ rails c
[1] pry(main)> I18n.t('authentication.failure.already_signed_up')
=> "You are already signed up."
```