### PR TITLE
User Ruby-supervised GitHub Action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7.x'
     - name: Build and test with Rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7.x'
+        ruby-version: '2.7.6'
     - name: Build and test with Rake
       env:
         RAILS_ENV: test


### PR DESCRIPTION
GitHub-supervised action `actions/setup-ruby@v1` is now deprecated See https://github.com/actions/setup-ruby

Use Ruby-supervised action `ruby/setup-ruby@v1` instead See https://github.com/ruby/setup-ruby

Resolves https://github.com/rakvium/blog/issues/115