### PR TITLE
get rid of coffeescript and bootstrap-sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,14 +19,11 @@ gem 'pg'
 gem 'puma'
 
 # Assets
-gem 'bootstrap-sass', '~> 3.4.1'
-gem 'coffee-rails'
 gem 'jquery-rails'
 gem 'less-rails', '~> 3.0.0'
 gem 'sass-rails'
 gem 'therubyracer'
 gem 'turbolinks'
-
 gem 'twitter-bootstrap-rails', '~> 5.0.0'
 gem 'uglifier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,14 +72,9 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    autoprefixer-rails (10.0.1.0)
-      execjs
     bcrypt (3.1.16)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     builder (3.3.0)
     cancancan (2.3.0)
     capybara (2.18.0)
@@ -94,13 +89,6 @@ GEM
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.3)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     commonjs (0.2.7)
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)
@@ -418,11 +406,9 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
-  bootstrap-sass (~> 3.4.1)
   cancancan (~> 2.0)
   capybara (~> 2.2)
   codeclimate-test-reporter (~> 1.0.0)
-  coffee-rails
   database_cleaner-active_record
   devise (~> 4.6)
   dotenv-rails

--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -1,3 +1,0 @@
-jQuery ->
-  $("a[rel~=popover], .has-popover").popover()
-  $("a[rel~=tooltip], .has-tooltip").tooltip()

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,5 +1,3 @@
-@import "bootstrap";
-
 /* header */
 
 #logo {


### PR DESCRIPTION
we don't need them anymore
after the [migration to bootstrap 5](https://github.com/rakvium/blog/pull/123)