### PR TITLE
remove extra navigation role from header and footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer navbar-fixed-bottom navbar-inverse" role="navigation">
+<footer class="footer navbar-fixed-bottom navbar-inverse">
   <small>
     <a href="http://railstutorial.org/">Rails Tutorial</a>
     by Michael Hartl

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="navbar navbar-fixed-top navbar-inverse" role="navigation">
+<header class="navbar navbar-fixed-top navbar-inverse">
   <div class="navbar-inner">
     <%= link_to '🌐 Blog', '/', id: 'logo' %>
     <nav>


### PR DESCRIPTION
according to google lighthouse:

Many HTML elements can only be assigned certain ARIA roles. Using ARIA roles where they are not allowed
can interfere with the accessibility of the web page. [Learn more about ARIA roles](https://dequeuniversity.com/rules/axe/4.9/aria-allowed-role). Failing Elements:
`header.navbar.navbar-fixed-top.navbar-inverse`
`footer.footer.navbar-fixed-bottom.navbar-inverse`