### PR TITLE
replace sass-rails with sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'puma'
 
 # Assets
 gem 'jquery-rails'
-gem 'sass-rails'
+gem 'sassc-rails'
 gem 'turbolinks'
 gem 'uglifier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,8 +336,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -432,7 +430,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails
-  sass-rails
+  sassc-rails
   selenium-webdriver (~> 2.37)
   shoulda-matchers (~> 6.4)
   simplecov


### PR DESCRIPTION
according to:

Post-install message from sass:

> Ruby Sass has reached end-of-life and should no longer be used.
> 
> * If you use Sass as a command-line tool, we recommend using Dart Sass, the new primary implementation: https://sass-lang.com/install
> 
> * If you use Sass as a plug-in for a Ruby web framework, we recommend using the sassc gem: https://github.com/sass/sassc-ruby#readme
> 
> * For more details, please refer to the Sass blog: https://sass-lang.com/blog/posts/7828841