### PR TITLE
replace uglifier with terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'puma'
 gem 'jquery-rails'
 gem 'sassc-rails'
 gem 'sprockets-rails'
+gem 'terser'
 gem 'turbolinks'
-gem 'uglifier'
 
 # Pagination
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,8 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stringio (3.1.1)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.0.10)
     timeout (0.4.1)
@@ -408,8 +410,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.6.0)
     useragent (0.16.10)
     warden (1.2.9)
@@ -472,8 +472,8 @@ DEPENDENCIES
   spring
   spring-watcher-listen
   sprockets-rails
+  terser
   turbolinks
-  uglifier
   will_paginate
   will_paginate-bootstrap
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,8 +24,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # Compress JavaScripts
+  config.assets.js_compressor = :terser
+  # Uconmment the next line to compress CSS
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
as uglifier is not compatible with es6
and thus results in the assets compilation fail:

```
-----> Installing node-v20.9.0-linux-x64
-----> Detecting rake tasks
-----> Preparing app for Rails asset pipeline
cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead
       Running: rake assets:precompile
       rake aborted!
       Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true). (Uglifier::Error)
       --
        408       SparkMD5.ArrayBuffer.hash = function(arr, raw) {
        409         var hash = md51_array(new Uint8Array(arr)), ret = hex(hash);
        410         return raw ? hexToBinaryString(ret) : ret;
        411       };
        412       return SparkMD5;
        413     }));
        414   })(sparkMd5);
        415   var SparkMD5 = sparkMd5.exports;
         =>   const fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice;
        417   class FileChecksum {
        418     static create(file, callback) {
        419       const instance = new FileChecksum(file);
        420       instance.create(callback);
        421     }
        422     constructor(file) {
        423       this.file = file;
        424       this.chunkSize = 2097152;
       ==
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/uglifier-4.2.1/lib/uglifier.rb:291:in `parse_result'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/uglifier-4.2.1/lib/uglifier.rb:221:in `run_uglifyjs'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/uglifier-4.2.1/lib/uglifier.rb:166:in `compile'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/uglifier_compressor.rb:53:in `call'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/uglifier_compressor.rb:28:in `call'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:75:in `call_processor'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:57:in `block in call_processors'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `reverse_each'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `call_processors'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:134:in `load_from_unloaded'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:60:in `block in load'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:317:in `fetch_asset_from_dependency_cache'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/loader.rb:44:in `load'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/cached_environment.rb:20:in `block in initialize'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/cached_environment.rb:47:in `load'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/base.rb:66:in `find_asset'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/base.rb:73:in `find_all_linked_assets'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:134:in `block in find'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:133:in `each'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:133:in `find'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:186:in `compile'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/task.rb:67:in `block (3 levels) in define'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-3.7.2/lib/rake/sprocketstask.rb:147:in `with_logger'
       /tmp/build_f90a1ee0/vendor/bundle/ruby/3.2.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/task.rb:66:in `block (2 levels) in define'
       Tasks: TOP => assets:precompile
       (See full trace by running task with --trace)

 !
 !     Precompiling assets failed.
```