### PR TITLE
Upgrade net-imap to 0.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     mustermann (4.0.0)
     mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
-    net-imap (0.5.7)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -414,7 +414,7 @@ GEM
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
-    timeout (0.4.3)
+    timeout (0.6.1)
     tsort (0.2.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)


### PR DESCRIPTION
to mitigate vulnerabilities affecting previous versions:

net-imap vulnerable to STARTTLS stripping via invalid response timing
[CVE-2026-42246](https://www.cve.org/CVERecord?id=CVE-2026-42246)
[GHSA-vcgp-9326-pqcp](https://github.com/advisories/GHSA-vcgp-9326-pqcp)

net-imap vulnerable to denial of service via high iteration count for `SCRAM-*` authentication
[CVE-2026-42256](https://www.cve.org/CVERecord?id=CVE-2026-42256)
[GHSA-87pf-fpwv-p7m7](https://github.com/advisories/GHSA-87pf-fpwv-p7m7)

net-imap vulnerable to command Injection via "raw" arguments to multiple commands
[CVE-2026-42257](https://www.cve.org/CVERecord?id=CVE-2026-42257)
[GHSA-hm49-wcqc-g2xg](https://github.com/advisories/GHSA-hm49-wcqc-g2xg)

net-imap vulnerable to command Injection via unvalidated Symbol inputs
[CVE-2026-42258](https://www.cve.org/CVERecord?id=CVE-2026-42258)
[GHSA-75xq-5h9v-w6px](https://github.com/advisories/GHSA-75xq-5h9v-w6px)