### PR TITLE
Upgrade addressable to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,8 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -274,7 +274,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (4.0.6)
+    public_suffix (7.0.5)
     puma (7.0.4)
       nio4r (~> 2.0)
     racc (1.8.1)


### PR DESCRIPTION
to mitigate a vulnerability present in version 2.8.0

CVE: CVE-2026-35611
GHSA: GHSA-h27x-rffw-24p4
Criticality: High
URL: https://github.com/sporkmonger/addressable/security/advisories/GHSA-h27x-rffw-24p4
Title: Addressable has a Regular Expression Denial of Service in Addressable templates
Solution: update to '>= 2.9.0'